### PR TITLE
Use main for the main branch name

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.md
+++ b/.github/ISSUE_TEMPLATE/1-bug.md
@@ -10,8 +10,8 @@ Ouch, sorry you’ve run into a bug.  Thank for taking the time to report it!
 Please fill in as much of the template below as you’re able.
 
 P.S. have you seen our support and contributing docs?
-https://github.com/get-alex/.github/blob/master/support.md
-https://github.com/get-alex/.github/blob/master/contributing.md
+https://github.com/get-alex/.github/blob/main/support.md
+https://github.com/get-alex/.github/blob/main/contributing.md
 -->
 
 ### Subject of the issue

--- a/.github/ISSUE_TEMPLATE/2-feature.md
+++ b/.github/ISSUE_TEMPLATE/2-feature.md
@@ -10,8 +10,8 @@ Thank you for suggesting an idea to make this project better!
 Please fill in as much of the template below as you’re able.
 
 P.S. have you seen our support and contributing docs?
-https://github.com/get-alex/.github/blob/master/support.md
-https://github.com/get-alex/.github/blob/master/contributing.md
+https://github.com/get-alex/.github/blob/main/support.md
+https://github.com/get-alex/.github/blob/main/contributing.md
 -->
 
 ### Subject of the feature

--- a/.github/ISSUE_TEMPLATE/3-help.md
+++ b/.github/ISSUE_TEMPLATE/3-help.md
@@ -12,6 +12,6 @@ Before opening a new issue, please search existing issues:
 https://github.com/search?q=org%3Aget-alex&type=Issues
 
 P.S. have you seen our support and contributing docs?
-https://github.com/get-alex/.github/blob/master/support.md
-https://github.com/get-alex/.github/blob/master/contributing.md
+https://github.com/get-alex/.github/blob/main/support.md
+https://github.com/get-alex/.github/blob/main/contributing.md
 -->

--- a/.github/pull-request-template.md
+++ b/.github/pull-request-template.md
@@ -1,5 +1,5 @@
 <!--
-Read the [contributing guidelines](https://github.com/get-alex/.github/blob/master/contributing.md).
+Read the [contributing guidelines](https://github.com/get-alex/.github/blob/main/contributing.md).
 
 We are excited about pull requests, but please try to limit the scope, provide a general description of the changes, and remember, it's up to you to convince us to land it.
 
@@ -8,6 +8,6 @@ If this fixes an open issue, link to it in the following way: `Closes GH-123`.
 New features and bug fixes should come with tests.
 
 P.S. have you seen our support and contributing docs?
-https://github.com/get-alex/.github/blob/master/support.md
-https://github.com/get-alex/.github/blob/master/contributing.md
+https://github.com/get-alex/.github/blob/main/support.md
+https://github.com/get-alex/.github/blob/main/contributing.md
 -->

--- a/contributing.md
+++ b/contributing.md
@@ -149,7 +149,7 @@ See [`support.md`][support] on how to get help.
 
 [author]: https://wooorm.com
 
-[coc]: https://github.com/get-alex/.github/blob/master/code-of-conduct.md
+[coc]: https://github.com/get-alex/.github/blob/main/code-of-conduct.md
 
 [unit-test]: https://twitter.com/sindresorhus/status/579306280495357953
 

--- a/support.md
+++ b/support.md
@@ -70,7 +70,7 @@ See [`contributing.md`][contributing] on how to contribute.
 
 [author]: https://wooorm.com
 
-[coc]: https://github.com/get-alex/.github/blob/master/code-of-conduct.md
+[coc]: https://github.com/get-alex/.github/blob/main/code-of-conduct.md
 
 [issues]: https://github.com/get-alex/alex/issues
 


### PR DESCRIPTION
I saw that some projects have already renamed their main branch to be `main` instead of master. This repo still needs to be done. This PR should help out some.

Steps for the maintainer:
1. Create a new branch called `main` that is based on the `master` branch, and push it up
2. In the GitHub project settings, change the default branch to be `main`
3. Change the target of this PR to be `main`
4. Merge this PR into `main`

Do not delete the `master` branch until all links across all repos are updated.
