### PR TITLE
Add mention of `retext-equality` for new words

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -100,8 +100,7 @@ built to the [`dest`][dest-folder] folder.
 If you have profanities, insensitive words, and/or any other additions to add
 to our repository, you’ll need to make a PR to either [`cuss`][cuss] or
 [`retext-equality`][equality].
-The words will automatically be added into [`retext-profanities`][profanities]
-and alex as well.
+The words will automatically be used in alex as well.
 
 ## Support
 

--- a/contributing.md
+++ b/contributing.md
@@ -98,7 +98,8 @@ built to the [`dest`][dest-folder] folder.
 ### Adding profanities and other words
 
 If you have profanities, insensitive words, and/or any other additions to add
-to our repository, you’ll need to make a PR to [`cuss`][cuss].
+to our repository, you’ll need to make a PR to either [`cuss`][cuss] or
+[`retext-equality`][equality].
 The words will automatically be added into [`retext-profanities`][profanities]
 and alex as well.
 


### PR DESCRIPTION
This is pretty minor but I thought it might help. I was trying to figure out where to check whether there has been discussions on a given word, and I think `retext-equality` should be mentioned alongside `cuss`.